### PR TITLE
Overhauled functions extracting titles from PDF/HTML documents

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: biocViews
-Version: 1.41.1
+Version: 1.41.2
 Title: Categorized views of R package repositories
 Author: VJ Carey <stvjc@channing.harvard.edu>,
         BJ Harshfield <rebjh@channing.harvard.edu>,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -14,8 +14,7 @@ importFrom(knitr, purl)
 
 importMethodsFrom(XML, saveXML)
 
-importFrom(XML, xmlNode, xmlOutputDOM, xmlTree, htmlParse,
-       getNodeSet, xmlValue)
+importFrom(XML, xmlNode, xmlOutputDOM, xmlTree, htmlParse, xpathApply, xmlValue)
 
 importFrom(RCurl, getURL)
 


### PR DESCRIPTION
Refactored the code which extracts PDF/HTML document titles in order to simplify this process, and to fix the following issues:
- more robust way of retrieving VignetteIndexEntry
- retrieve VignetteIndexEntry from .Rmd/.Rhtml source files rather than .html output
- look for .Rmd vignette source if no .Rnw file found