### PR TITLE
add hasAuthorsAtR field in dbMat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,3 +30,4 @@ Collate: AllClasses.R AllGenerics.R as-methods.R htmlDoc-methods.R
 VignetteBuilder: knitr
 RoxygenNote: 7.3.2
 Encoding: UTF-8
+RoxygenNote: 7.3.2

--- a/R/repository.R
+++ b/R/repository.R
@@ -449,6 +449,22 @@ getFileExistsAttr <- function(pkgList, reposRootPath, dir, filename) {
     }))
 }
 
+DESCfieldExistsAttr <- function(pkgList, reposRootPath, field) {
+    vapply(
+        pkgList,
+        function(pkg) {
+            filedir <- file.path(reposRootPath, pkg)
+            file <- file.path(filedir, "DESCRIPTION")
+            result <- file.exists(file)
+            if (result) {
+                field <- as.character(read.dcf(file, fields = field))
+                result <- !is.na(field) && identical(length(field), 1L)
+            }
+            result
+        }, logical(1L)
+    )
+}
+
 getFileLinks <- function(pkgList, reposRootPath, vignette.dir, ext,
                          ignore.case=FALSE) {
     if (length(pkgList) == 0L)
@@ -720,6 +736,8 @@ write_VIEWS <- function(reposRootPath, fields = NULL,
     install <- getFileExistsAttr(dbMat[, "Package"], reposRootPath, "install", "INSTALL")
     license <- getFileExistsAttr(dbMat[, "Package"], reposRootPath, "licenses",
                                  "LICENSE")
+    authorsr <-
+        DESCfieldExistsAttr(dbMat[, "Package"], reposRootPath, "Authors@R")
 
     # add additional values to matrix for writing
     dbMat <- cbind(dbMat, allVigs)
@@ -729,9 +747,10 @@ write_VIEWS <- function(reposRootPath, fields = NULL,
     dbMat <- cbind(dbMat, install)
     dbMat <- cbind(dbMat, license)
     dbMat <- cbind(dbMat, rfiles)
+    dbMat <- cbind(dbMat, authorsr)
 
     colnames(dbMat) <- c(fldNames, "vignettes", "vignetteTitles", "hasREADME",
-        "hasNEWS", "hasINSTALL", "hasLICENSE", "Rfiles")
+        "hasNEWS", "hasINSTALL", "hasLICENSE", "Rfiles", "hasAuthorsAtR")
 
     # get reverse dependency list including CRAN
     all_repos <- repositories()

--- a/R/repository.R
+++ b/R/repository.R
@@ -458,7 +458,7 @@ DESCfieldExistsAttr <- function(pkgList, reposRootPath, field) {
             result <- file.exists(file)
             if (result) {
                 field <- as.character(read.dcf(file, fields = field))
-                result <- !is.na(field) && identical(length(field), 1L)
+                result <- identical(length(field), 1L) && !is.na(field)
             }
             result
         }, logical(1L)


### PR DESCRIPTION
Hi Lori, @lshep 

It would be good to include the `hasAuthorsAtR` field in the `VIEWS` file.
This would help us identify more easily what packages need to use this field in the `DESCRIPTION` file. 

https://bioconductor.org/packages/release/bioc/VIEWS
https://bioconductor.org/packages/devel/bioc/VIEWS

related to: https://github.com/seandavi/BiocPkgTools/issues/65